### PR TITLE
css edites

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,7 @@
+*{
+    box-sizing: border-box;
+}
+
 body{
     background-color:#0a0a23;
     font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
box-sizing property is set to border-box instead of being set to the standard content-box(that the browser sets), this change makes the total width of the element, in this case the img and its padding and border fit within the container